### PR TITLE
fix: gh action tag env overriding actual tag while push from main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,9 @@ jobs:
         make oci-manifest-push
 
     - name: Tag as latest (main branch only)
-      if: github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       run: |
         make oci-tag
         make oci-push
       env:
-        IMAGE_TAG: latest
+        IMAGE_TARGET_TAG: latest

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ oci-manifest-push:
 	${CONTAINER_MANAGER} manifest push $(IMAGE_NAME)
 
 oci-tag:
-	${CONTAINER_MANAGER} tag $(IMAGE_NAME) $(IMAGE_REPO):$(IMAGE_TAG)
+	${CONTAINER_MANAGER} tag $(IMAGE_NAME) $(IMAGE_REPO):$(IMAGE_TARGET_TAG)
 
 oci-push:
 	${CONTAINER_MANAGER} push $(IMAGE_NAME)


### PR DESCRIPTION
Previously it used IMAGE_TAG for both source and target tags when tagging for push latest commit to main. This will add a new ENV to set the TARGET_TAG. Fixes #19.